### PR TITLE
Add repository-scoped activity filtering (-repos)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Build**: `make build` - Builds the binary to `./ghdump`
 - **Run**: `./ghdump -since YYYY-MM-DD -until YYYY-MM-DD -author username` - Run the built binary
-- **Test**: No test suite is configured in this repository
+- **Test**: `make test`
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This is a Go CLI application that fetches GitHub activity data and generates Mar
 ### Key Implementation Details
 
 - Uses GitHub Search API for issues and PRs to filter by author and date range
-- Organization filtering is applied client-side by parsing repository URLs
+- Organization and repository filtering (-orgs, -repos) is applied client-side by parsing repository URLs; when both are set, a repository must satisfy both filters
 - Review fetching is limited to 100 PRs maximum to avoid API timeouts
 - Both PR reviews and review comments are collected for comprehensive review data
 - Report includes status indicators (🔴 open, ✅ closed/approved, 🟣 merged, 🔄 changes requested)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 BINARY_NAME=ghdump
 
-.PHONY: build
+.PHONY: build test
 
 build:
 	go build -o $(BINARY_NAME) .
+
+test:
+	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A tool to fetch GitHub activity for a specified period and generate Markdown rep
 
 ## Features
 
-- Fetch Issues within a specified period from specified organizations
-- Fetch Pull Requests within a specified period from specified organizations
-- Fetch reviewed Pull Requests within a specified period from specified organizations
+- Fetch Issues within a specified period from specified organizations or repositories
+- Fetch Pull Requests within a specified period from specified organizations or repositories
+- Fetch reviewed Pull Requests within a specified period from specified organizations or repositories
 - Generate reports in Markdown format
 
 ## Prerequisites
@@ -54,6 +54,8 @@ Usage of ghdump:
     	Comma-separated list of GitHub organizations (optional: if not specified, searches all organizations)
   -output string
     	Output file path (optional)
+  -repos string
+    	Comma-separated list of GitHub repositories in owner/repo format (optional: if not specified, searches all repositories)
   -since string
     	Start date (YYYY-MM-DD)
   -until string
@@ -74,6 +76,9 @@ GITHUB_TOKEN=$(gh auth token) ghdump -since 2025-01-01 -until 2025-06-30 -author
 
 # Target specific organizations only
 GITHUB_TOKEN=$(gh auth token) ghdump -since 2025-01-01 -until 2025-06-30 -author username -orgs "myorg,anotherorg" -output specific-orgs-report.md
+
+# Target specific repositories only
+GITHUB_TOKEN=$(gh auth token) ghdump -since 2025-01-01 -until 2025-06-30 -author username -repos "myorg/repo1,myorg/repo2" -output specific-repos-report.md
 ```
 
 ## Report Format

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -23,6 +24,12 @@ func NewClient(orgs, repos []string) (*Client, error) {
 		return nil, fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
+	for _, repo := range repos {
+		if !isValidRepoFullName(repo) {
+			return nil, fmt.Errorf("invalid repository %q: expected owner/repo format", repo)
+		}
+	}
+
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
@@ -36,6 +43,26 @@ func NewClient(orgs, repos []string) (*Client, error) {
 	}, nil
 }
 
+// isValidRepoFullName reports whether repo is in "owner/repo" form.
+func isValidRepoFullName(repo string) bool {
+	owner, name, ok := strings.Cut(repo, "/")
+	return ok && owner != "" && name != "" && !strings.Contains(name, "/")
+}
+
+// repoFullNameFromURL extracts the "owner/repo" full name from a GitHub HTML
+// URL such as https://github.com/owner/repo/issues/123. It reports false if
+// htmlURL is nil or doesn't have the expected shape.
+func repoFullNameFromURL(htmlURL *string) (string, bool) {
+	if htmlURL == nil {
+		return "", false
+	}
+	urlParts := strings.Split(*htmlURL, "/")
+	if len(urlParts) < 6 {
+		return "", false
+	}
+	return urlParts[3] + "/" + urlParts[4], true
+}
+
 // shouldIncludeRepo reports whether repoFullName (e.g. "owner/repo") passes
 // the configured org and repo filters. If repos are specified, only exact
 // (case-insensitive) matches are included. If orgs are specified, only repos
@@ -43,29 +70,17 @@ func NewClient(orgs, repos []string) (*Client, error) {
 // AND when set. GitHub owner/repo names are case-insensitive, so matching
 // uses strings.EqualFold rather than exact comparison.
 func (g *Client) shouldIncludeRepo(repoFullName string) bool {
-	if len(g.repos) > 0 {
-		matched := false
-		for _, repo := range g.repos {
-			if strings.EqualFold(repoFullName, repo) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false
-		}
+	if len(g.repos) > 0 && !slices.ContainsFunc(g.repos, func(repo string) bool {
+		return strings.EqualFold(repoFullName, repo)
+	}) {
+		return false
 	}
 
 	if len(g.orgs) > 0 {
 		owner, _, _ := strings.Cut(repoFullName, "/")
-		matched := false
-		for _, org := range g.orgs {
-			if strings.EqualFold(owner, org) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
+		if !slices.ContainsFunc(g.orgs, func(org string) bool {
+			return strings.EqualFold(owner, org)
+		}) {
 			return false
 		}
 	}
@@ -100,47 +115,44 @@ func (g *Client) GetIssues(
 		for _, issue := range result.Issues {
 			// Skip results missing the fields required to map an Issue,
 			// e.g. issues from since-deleted GitHub accounts have a nil User.
-			if issue.HTMLURL == nil || issue.User == nil || issue.User.Login == nil {
+			if issue.User == nil || issue.User.Login == nil {
 				continue
 			}
 
-			// Parse repository from URL like https://github.com/owner/repo/issues/123
-			urlParts := strings.Split(*issue.HTMLURL, "/")
-			if len(urlParts) < 6 {
+			repoFullName, ok := repoFullNameFromURL(issue.HTMLURL)
+			if !ok || !g.shouldIncludeRepo(repoFullName) {
 				continue
 			}
 
-			repoFullName := urlParts[3] + "/" + urlParts[4]
-
-			if g.shouldIncludeRepo(repoFullName) {
-				body := ""
-				if includeBody && issue.Body != nil {
-					body = *issue.Body
-				}
-
-				mappedIssue := Issue{
-					Number:    *issue.Number,
-					Title:     *issue.Title,
-					Body:      body,
-					State:     *issue.State,
-					CreatedAt: issue.CreatedAt.Time,
-					UpdatedAt: issue.UpdatedAt.Time,
-					HTMLURL:   *issue.HTMLURL,
-					Repository: struct {
-						Name     string `json:"name"`
-						FullName string `json:"full_name"`
-					}{
-						Name:     urlParts[4],
-						FullName: repoFullName,
-					},
-					User: struct {
-						Login string `json:"login"`
-					}{
-						Login: *issue.User.Login,
-					},
-				}
-				allIssues = append(allIssues, mappedIssue)
+			body := ""
+			if includeBody && issue.Body != nil {
+				body = *issue.Body
 			}
+
+			_, repoName, _ := strings.Cut(repoFullName, "/")
+
+			mappedIssue := Issue{
+				Number:    *issue.Number,
+				Title:     *issue.Title,
+				Body:      body,
+				State:     *issue.State,
+				CreatedAt: issue.CreatedAt.Time,
+				UpdatedAt: issue.UpdatedAt.Time,
+				HTMLURL:   *issue.HTMLURL,
+				Repository: struct {
+					Name     string `json:"name"`
+					FullName string `json:"full_name"`
+				}{
+					Name:     repoName,
+					FullName: repoFullName,
+				},
+				User: struct {
+					Login string `json:"login"`
+				}{
+					Login: *issue.User.Login,
+				},
+			}
+			allIssues = append(allIssues, mappedIssue)
 		}
 
 		if resp.NextPage == 0 {
@@ -179,57 +191,54 @@ func (g *Client) GetPullRequests(
 		for _, issue := range result.Issues {
 			// Skip results missing the fields required to map a PullRequest,
 			// e.g. issues from since-deleted GitHub accounts have a nil User.
-			if issue.HTMLURL == nil || issue.User == nil || issue.User.Login == nil {
+			if issue.User == nil || issue.User.Login == nil {
 				continue
 			}
 
-			// Parse repository from URL like https://github.com/owner/repo/pull/123
-			urlParts := strings.Split(*issue.HTMLURL, "/")
-			if len(urlParts) < 6 {
+			repoFullName, ok := repoFullNameFromURL(issue.HTMLURL)
+			if !ok || !g.shouldIncludeRepo(repoFullName) {
 				continue
 			}
 
-			repoFullName := urlParts[3] + "/" + urlParts[4]
-
-			if g.shouldIncludeRepo(repoFullName) {
-				body := ""
-				if includeBody && issue.Body != nil {
-					body = *issue.Body
-				}
-
-				// The search API reports issue state as "open"/"closed" only;
-				// a merged PR is inferred from the pull_request.merged_at field.
-				state := *issue.State
-				var mergedAt *time.Time
-				if issue.PullRequestLinks != nil && issue.PullRequestLinks.MergedAt != nil {
-					mergedAt = &issue.PullRequestLinks.MergedAt.Time
-					state = "merged"
-				}
-
-				mappedPR := PullRequest{
-					Number:    *issue.Number,
-					Title:     *issue.Title,
-					Body:      body,
-					State:     state,
-					CreatedAt: issue.CreatedAt.Time,
-					UpdatedAt: issue.UpdatedAt.Time,
-					MergedAt:  mergedAt,
-					HTMLURL:   *issue.HTMLURL,
-					Repository: struct {
-						Name     string `json:"name"`
-						FullName string `json:"full_name"`
-					}{
-						Name:     urlParts[4],
-						FullName: repoFullName,
-					},
-					User: struct {
-						Login string `json:"login"`
-					}{
-						Login: *issue.User.Login,
-					},
-				}
-				allPRs = append(allPRs, mappedPR)
+			body := ""
+			if includeBody && issue.Body != nil {
+				body = *issue.Body
 			}
+
+			// The search API reports issue state as "open"/"closed" only;
+			// a merged PR is inferred from the pull_request.merged_at field.
+			state := *issue.State
+			var mergedAt *time.Time
+			if issue.PullRequestLinks != nil && issue.PullRequestLinks.MergedAt != nil {
+				mergedAt = &issue.PullRequestLinks.MergedAt.Time
+				state = "merged"
+			}
+
+			_, repoName, _ := strings.Cut(repoFullName, "/")
+
+			mappedPR := PullRequest{
+				Number:    *issue.Number,
+				Title:     *issue.Title,
+				Body:      body,
+				State:     state,
+				CreatedAt: issue.CreatedAt.Time,
+				UpdatedAt: issue.UpdatedAt.Time,
+				MergedAt:  mergedAt,
+				HTMLURL:   *issue.HTMLURL,
+				Repository: struct {
+					Name     string `json:"name"`
+					FullName string `json:"full_name"`
+				}{
+					Name:     repoName,
+					FullName: repoFullName,
+				},
+				User: struct {
+					Login string `json:"login"`
+				}{
+					Login: *issue.User.Login,
+				},
+			}
+			allPRs = append(allPRs, mappedPR)
 		}
 
 		if resp.NextPage == 0 {
@@ -271,29 +280,17 @@ func (g *Client) GetReviewedPullRequests(
 				return allReviews, nil
 			}
 
-			// Extract repository info from the issue URL
-			if issue.HTMLURL == nil {
-				continue
-			}
-
-			// Parse repository from URL like https://github.com/owner/repo/pull/123
-			urlParts := strings.Split(*issue.HTMLURL, "/")
-			if len(urlParts) < 6 {
-				continue
-			}
-
-			repoFullName := urlParts[3] + "/" + urlParts[4]
-
-			if !g.shouldIncludeRepo(repoFullName) {
+			repoFullName, ok := repoFullNameFromURL(issue.HTMLURL)
+			if !ok || !g.shouldIncludeRepo(repoFullName) {
 				continue
 			}
 
 			processedPRs++
 
 			// Get reviews for this PR
-			parts := strings.Split(repoFullName, "/")
-			if len(parts) == 2 {
-				reviews, _, err := g.client.PullRequests.ListReviews(ctx, parts[0], parts[1], *issue.Number, nil)
+			owner, repo, ok := strings.Cut(repoFullName, "/")
+			if ok {
+				reviews, _, err := g.client.PullRequests.ListReviews(ctx, owner, repo, *issue.Number, nil)
 				if err != nil {
 					continue
 				}
@@ -301,8 +298,8 @@ func (g *Client) GetReviewedPullRequests(
 				// Also get review comments for this PR
 				reviewComments, _, err := g.client.PullRequests.ListComments(
 					ctx,
-					parts[0],
-					parts[1],
+					owner,
+					repo,
 					*issue.Number,
 					nil,
 				)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,9 +14,10 @@ import (
 type Client struct {
 	client *github.Client
 	orgs   []string
+	repos  []string
 }
 
-func NewClient(orgs []string) (*Client, error) {
+func NewClient(orgs, repos []string) (*Client, error) {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("GITHUB_TOKEN environment variable is required")
@@ -31,7 +32,42 @@ func NewClient(orgs []string) (*Client, error) {
 	return &Client{
 		client: client,
 		orgs:   orgs,
+		repos:  repos,
 	}, nil
+}
+
+// shouldIncludeRepo reports whether repoFullName (e.g. "owner/repo") passes
+// the configured org and repo filters. If repos are specified, only exact
+// matches are included. If orgs are specified, only repos owned by one of
+// those orgs are included. Both filters are combined with AND when set.
+func (g *Client) shouldIncludeRepo(repoFullName string) bool {
+	if len(g.repos) > 0 {
+		matched := false
+		for _, repo := range g.repos {
+			if repoFullName == repo {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	if len(g.orgs) > 0 {
+		matched := false
+		for _, org := range g.orgs {
+			if strings.HasPrefix(repoFullName, org+"/") {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (g *Client) GetIssues(
@@ -73,18 +109,7 @@ func (g *Client) GetIssues(
 
 			repoFullName := urlParts[3] + "/" + urlParts[4]
 
-			// Check if the repository belongs to target organizations (if specified)
-			shouldInclude := len(g.orgs) == 0 // Include all if no orgs specified
-			if !shouldInclude {
-				for _, org := range g.orgs {
-					if strings.HasPrefix(repoFullName, org+"/") {
-						shouldInclude = true
-						break
-					}
-				}
-			}
-
-			if shouldInclude {
+			if g.shouldIncludeRepo(repoFullName) {
 				body := ""
 				if includeBody && issue.Body != nil {
 					body = *issue.Body
@@ -163,18 +188,7 @@ func (g *Client) GetPullRequests(
 
 			repoFullName := urlParts[3] + "/" + urlParts[4]
 
-			// Check if the repository belongs to target organizations (if specified)
-			shouldInclude := len(g.orgs) == 0 // Include all if no orgs specified
-			if !shouldInclude {
-				for _, org := range g.orgs {
-					if strings.HasPrefix(repoFullName, org+"/") {
-						shouldInclude = true
-						break
-					}
-				}
-			}
-
-			if shouldInclude {
+			if g.shouldIncludeRepo(repoFullName) {
 				body := ""
 				if includeBody && issue.Body != nil {
 					body = *issue.Body
@@ -267,17 +281,7 @@ func (g *Client) GetReviewedPullRequests(
 
 			repoFullName := urlParts[3] + "/" + urlParts[4]
 
-			// Check if the repository belongs to target organizations (if specified)
-			shouldInclude := len(g.orgs) == 0 // Include all if no orgs specified
-			if !shouldInclude {
-				for _, org := range g.orgs {
-					if strings.HasPrefix(repoFullName, org+"/") {
-						shouldInclude = true
-						break
-					}
-				}
-			}
-			if !shouldInclude {
+			if !g.shouldIncludeRepo(repoFullName) {
 				continue
 			}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -38,13 +38,15 @@ func NewClient(orgs, repos []string) (*Client, error) {
 
 // shouldIncludeRepo reports whether repoFullName (e.g. "owner/repo") passes
 // the configured org and repo filters. If repos are specified, only exact
-// matches are included. If orgs are specified, only repos owned by one of
-// those orgs are included. Both filters are combined with AND when set.
+// (case-insensitive) matches are included. If orgs are specified, only repos
+// owned by one of those orgs are included. Both filters are combined with
+// AND when set. GitHub owner/repo names are case-insensitive, so matching
+// uses strings.EqualFold rather than exact comparison.
 func (g *Client) shouldIncludeRepo(repoFullName string) bool {
 	if len(g.repos) > 0 {
 		matched := false
 		for _, repo := range g.repos {
-			if repoFullName == repo {
+			if strings.EqualFold(repoFullName, repo) {
 				matched = true
 				break
 			}
@@ -55,9 +57,10 @@ func (g *Client) shouldIncludeRepo(repoFullName string) bool {
 	}
 
 	if len(g.orgs) > 0 {
+		owner, _, _ := strings.Cut(repoFullName, "/")
 		matched := false
 		for _, org := range g.orgs {
-			if strings.HasPrefix(repoFullName, org+"/") {
+			if strings.EqualFold(owner, org) {
 				matched = true
 				break
 			}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -59,8 +59,9 @@ func (g *Client) GetIssues(
 		}
 
 		for _, issue := range result.Issues {
-			// Extract repository info from the issue URL
-			if issue.HTMLURL == nil {
+			// Skip results missing the fields required to map an Issue,
+			// e.g. issues from since-deleted GitHub accounts have a nil User.
+			if issue.HTMLURL == nil || issue.User == nil || issue.User.Login == nil {
 				continue
 			}
 
@@ -148,8 +149,9 @@ func (g *Client) GetPullRequests(
 		}
 
 		for _, issue := range result.Issues {
-			// Extract repository info from the issue URL
-			if issue.HTMLURL == nil {
+			// Skip results missing the fields required to map a PullRequest,
+			// e.g. issues from since-deleted GitHub accounts have a nil User.
+			if issue.HTMLURL == nil || issue.User == nil || issue.User.Login == nil {
 				continue
 			}
 
@@ -173,18 +175,25 @@ func (g *Client) GetPullRequests(
 			}
 
 			if shouldInclude {
-				var mergedAt *time.Time
-
 				body := ""
 				if includeBody && issue.Body != nil {
 					body = *issue.Body
+				}
+
+				// The search API reports issue state as "open"/"closed" only;
+				// a merged PR is inferred from the pull_request.merged_at field.
+				state := *issue.State
+				var mergedAt *time.Time
+				if issue.PullRequestLinks != nil && issue.PullRequestLinks.MergedAt != nil {
+					mergedAt = &issue.PullRequestLinks.MergedAt.Time
+					state = "merged"
 				}
 
 				mappedPR := PullRequest{
 					Number:    *issue.Number,
 					Title:     *issue.Title,
 					Body:      body,
-					State:     *issue.State,
+					State:     state,
 					CreatedAt: issue.CreatedAt.Time,
 					UpdatedAt: issue.UpdatedAt.Time,
 					MergedAt:  mergedAt,

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -48,7 +48,7 @@ func TestShouldIncludeRepo(t *testing.T) {
 			repoFullName: "myorg/myrepo",
 			want:         true,
 		},
-		"repo filter takes precedence over unrelated org filter": {
+		"org mismatch excludes despite a matching repo filter": {
 			orgs:         []string{"otherorg"},
 			repos:        []string{"myorg/myrepo"},
 			repoFullName: "myorg/myrepo",

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -23,6 +23,11 @@ func TestShouldIncludeRepo(t *testing.T) {
 			repoFullName: "myorg/myrepo",
 			want:         false,
 		},
+		"org match is case-insensitive": {
+			orgs:         []string{"MyOrg"},
+			repoFullName: "myorg/myrepo",
+			want:         true,
+		},
 		"org prefix does not falsely match a similarly named org": {
 			orgs:         []string{"my"},
 			repoFullName: "myorg/myrepo",
@@ -37,6 +42,11 @@ func TestShouldIncludeRepo(t *testing.T) {
 			repos:        []string{"myorg/other"},
 			repoFullName: "myorg/myrepo",
 			want:         false,
+		},
+		"repo match is case-insensitive": {
+			repos:        []string{"MyOrg/MyRepo"},
+			repoFullName: "myorg/myrepo",
+			want:         true,
 		},
 		"repo filter takes precedence over unrelated org filter": {
 			orgs:         []string{"otherorg"},

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -71,3 +71,46 @@ func TestShouldIncludeRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidRepoFullName(t *testing.T) {
+	cases := map[string]struct {
+		repo string
+		want bool
+	}{
+		"valid owner/repo":  {repo: "myorg/myrepo", want: true},
+		"missing owner":     {repo: "myrepo", want: false},
+		"empty owner":       {repo: "/myrepo", want: false},
+		"empty repo":        {repo: "myorg/", want: false},
+		"too many segments": {repo: "myorg/myrepo/extra", want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isValidRepoFullName(tc.repo); got != tc.want {
+				t.Errorf("isValidRepoFullName(%q) = %v, want %v", tc.repo, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepoFullNameFromURL(t *testing.T) {
+	url := "https://github.com/myorg/myrepo/issues/123"
+
+	cases := map[string]struct {
+		htmlURL  *string
+		wantName string
+		wantOK   bool
+	}{
+		"valid issue URL": {htmlURL: &url, wantName: "myorg/myrepo", wantOK: true},
+		"nil URL":         {htmlURL: nil, wantName: "", wantOK: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotName, gotOK := repoFullNameFromURL(tc.htmlURL)
+			if gotName != tc.wantName || gotOK != tc.wantOK {
+				t.Errorf("repoFullNameFromURL(%v) = (%q, %v), want (%q, %v)", tc.htmlURL, gotName, gotOK, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,63 @@
+package github
+
+import "testing"
+
+func TestShouldIncludeRepo(t *testing.T) {
+	cases := map[string]struct {
+		orgs         []string
+		repos        []string
+		repoFullName string
+		want         bool
+	}{
+		"no filters includes everything": {
+			repoFullName: "myorg/myrepo",
+			want:         true,
+		},
+		"org match": {
+			orgs:         []string{"myorg"},
+			repoFullName: "myorg/myrepo",
+			want:         true,
+		},
+		"org mismatch": {
+			orgs:         []string{"otherorg"},
+			repoFullName: "myorg/myrepo",
+			want:         false,
+		},
+		"org prefix does not falsely match a similarly named org": {
+			orgs:         []string{"my"},
+			repoFullName: "myorg/myrepo",
+			want:         false,
+		},
+		"repo exact match": {
+			repos:        []string{"myorg/myrepo"},
+			repoFullName: "myorg/myrepo",
+			want:         true,
+		},
+		"repo mismatch": {
+			repos:        []string{"myorg/other"},
+			repoFullName: "myorg/myrepo",
+			want:         false,
+		},
+		"repo filter takes precedence over unrelated org filter": {
+			orgs:         []string{"otherorg"},
+			repos:        []string{"myorg/myrepo"},
+			repoFullName: "myorg/myrepo",
+			want:         false,
+		},
+		"repo and org filters combine with AND": {
+			orgs:         []string{"myorg"},
+			repos:        []string{"myorg/myrepo"},
+			repoFullName: "myorg/myrepo",
+			want:         true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &Client{orgs: tc.orgs, repos: tc.repos}
+			if got := c.shouldIncludeRepo(tc.repoFullName); got != tc.want {
+				t.Errorf("shouldIncludeRepo(%q) = %v, want %v", tc.repoFullName, got, tc.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,13 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	var (
 		since       = flag.String("since", "", "Start date (YYYY-MM-DD)")
 		until       = flag.String("until", "", "End date (YYYY-MM-DD)")
@@ -24,101 +31,59 @@ func main() {
 	)
 	flag.Parse()
 
-	if *since == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: -since is required\n")
-		flag.Usage()
-		os.Exit(1)
+	requiredFlags := []struct {
+		name  string
+		value string
+	}{
+		{"since", *since},
+		{"until", *until},
+		{"author", *author},
 	}
-
-	if *until == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: -until is required\n")
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	if *author == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: -author is required\n")
-		flag.Usage()
-		os.Exit(1)
+	for _, f := range requiredFlags {
+		if f.value == "" {
+			flag.Usage()
+			return fmt.Errorf("-%s is required", f.name)
+		}
 	}
 
 	sinceTime, err := time.Parse("2006-01-02", *since)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error parsing since date: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("parsing since date: %w", err)
 	}
 
 	untilTime, err := time.Parse("2006-01-02", *until)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error parsing until date: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("parsing until date: %w", err)
 	}
 
-	var orgList []string
-	if *orgs != "" {
-		orgList = strings.Split(*orgs, ",")
-		for i, org := range orgList {
-			orgList[i] = strings.TrimSpace(org)
-		}
-	}
-
-	var repoList []string
-	if *repos != "" {
-		repoList = strings.Split(*repos, ",")
-		for i, repo := range repoList {
-			repoList[i] = strings.TrimSpace(repo)
-		}
-	}
+	orgList := splitAndTrim(*orgs)
+	repoList := splitAndTrim(*repos)
 
 	client, err := github.NewClient(orgList, repoList)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error creating GitHub client: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("creating GitHub client: %w", err)
 	}
+
+	printConfiguration(*since, *until, *author, *includeBody, *orgs, *repos, *output)
 
 	ctx := context.Background()
-
-	// Display configuration
-	_, _ = fmt.Fprintf(os.Stderr, "Configuration:\n")
-	_, _ = fmt.Fprintf(os.Stderr, "  Period: %s - %s\n", *since, *until)
-	_, _ = fmt.Fprintf(os.Stderr, "  Author: %s\n", *author)
-	_, _ = fmt.Fprintf(os.Stderr, "  Include body: %t\n", *includeBody)
-	if *orgs != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "  Organizations: %s\n", *orgs)
-	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "  Organizations: all\n")
-	}
-	if *repos != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "  Repositories: %s\n", *repos)
-	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "  Repositories: all\n")
-	}
-	if *output != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "  Output: %s\n", *output)
-	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "  Output: stdout\n")
-	}
-	_, _ = fmt.Fprintf(os.Stderr, "\n")
 
 	_, _ = fmt.Fprintf(os.Stderr, "Fetching issues...\n")
 	issues, err := client.GetIssues(ctx, sinceTime, untilTime, *author, *includeBody)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error fetching issues: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("fetching issues: %w", err)
 	}
 
 	_, _ = fmt.Fprintf(os.Stderr, "Fetching pull requests...\n")
 	prs, err := client.GetPullRequests(ctx, sinceTime, untilTime, *author, *includeBody)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error fetching pull requests: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("fetching pull requests: %w", err)
 	}
 
 	_, _ = fmt.Fprintf(os.Stderr, "Fetching reviews...\n")
 	reviews, err := client.GetReviewedPullRequests(ctx, sinceTime, untilTime, *author)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error fetching reviews: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("fetching reviews: %w", err)
 	}
 
 	report := reporter.New(*includeBody).GenerateMarkdownReport(
@@ -130,13 +95,50 @@ func main() {
 		*author,
 	)
 
-	if *output != "" {
-		if err := os.WriteFile(*output, []byte(report), 0644); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error writing to file: %v\n", err)
-			os.Exit(1)
-		}
-		_, _ = fmt.Fprintf(os.Stderr, "Report written to %s\n", *output)
-	} else {
+	if *output == "" {
 		fmt.Print(report)
+		return nil
 	}
+
+	if err := os.WriteFile(*output, []byte(report), 0644); err != nil {
+		return fmt.Errorf("writing to file: %w", err)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Report written to %s\n", *output)
+
+	return nil
+}
+
+// printConfiguration prints the resolved run configuration to stderr.
+func printConfiguration(since, until, author string, includeBody bool, orgs, repos, output string) {
+	_, _ = fmt.Fprintf(os.Stderr, "Configuration:\n")
+	_, _ = fmt.Fprintf(os.Stderr, "  Period: %s - %s\n", since, until)
+	_, _ = fmt.Fprintf(os.Stderr, "  Author: %s\n", author)
+	_, _ = fmt.Fprintf(os.Stderr, "  Include body: %t\n", includeBody)
+	printFilterLine("Organizations", orgs, "all")
+	printFilterLine("Repositories", repos, "all")
+	printFilterLine("Output", output, "stdout")
+	_, _ = fmt.Fprintf(os.Stderr, "\n")
+}
+
+// printFilterLine prints a single "label: value" configuration line, falling
+// back to defaultValue when value is empty, e.g. printFilterLine("Output",
+// "", "stdout") prints "  Output: stdout".
+func printFilterLine(label, value, defaultValue string) {
+	if value == "" {
+		value = defaultValue
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "  %s: %s\n", label, value)
+}
+
+// splitAndTrim splits a comma-separated flag value into trimmed elements,
+// returning nil for an empty string.
+func splitAndTrim(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 		output      = flag.String("output", "", "Output file path (optional)")
 		includeBody = flag.Bool("body", true, "Include issue/PR descriptions")
 		orgs        = flag.String("orgs", "", "Comma-separated list of GitHub organizations (optional: if not specified, searches all organizations)")
+		repos       = flag.String("repos", "", "Comma-separated list of GitHub repositories in owner/repo format (optional: if not specified, searches all repositories)")
 	)
 	flag.Parse()
 
@@ -61,7 +62,19 @@ func main() {
 		}
 	}
 
-	client, err := github.NewClient(orgList)
+	var repoList []string
+	if *repos != "" {
+		repoList = strings.Split(*repos, ",")
+		for i, repo := range repoList {
+			repoList[i] = strings.TrimSpace(repo)
+		}
+	}
+	if err := validateRepoFormat(repoList); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	client, err := github.NewClient(orgList, repoList)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error creating GitHub client: %v\n", err)
 		os.Exit(1)
@@ -78,6 +91,11 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "  Organizations: %s\n", *orgs)
 	} else {
 		_, _ = fmt.Fprintf(os.Stderr, "  Organizations: all\n")
+	}
+	if *repos != "" {
+		_, _ = fmt.Fprintf(os.Stderr, "  Repositories: %s\n", *repos)
+	} else {
+		_, _ = fmt.Fprintf(os.Stderr, "  Repositories: all\n")
 	}
 	if *output != "" {
 		_, _ = fmt.Fprintf(os.Stderr, "  Output: %s\n", *output)
@@ -125,4 +143,15 @@ func main() {
 	} else {
 		fmt.Print(report)
 	}
+}
+
+// validateRepoFormat checks that each -repos entry is in owner/repo form.
+func validateRepoFormat(repos []string) error {
+	for _, repo := range repos {
+		owner, name, ok := strings.Cut(repo, "/")
+		if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+			return fmt.Errorf("invalid -repos entry %q: expected owner/repo format", repo)
+		}
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -69,10 +69,6 @@ func main() {
 			repoList[i] = strings.TrimSpace(repo)
 		}
 	}
-	if err := validateRepoFormat(repoList); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
 
 	client, err := github.NewClient(orgList, repoList)
 	if err != nil {
@@ -143,15 +139,4 @@ func main() {
 	} else {
 		fmt.Print(report)
 	}
-}
-
-// validateRepoFormat checks that each -repos entry is in owner/repo form.
-func validateRepoFormat(repos []string) error {
-	for _, repo := range repos {
-		owner, name, ok := strings.Cut(repo, "/")
-		if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
-			return fmt.Errorf("invalid -repos entry %q: expected owner/repo format", repo)
-		}
-	}
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -130,15 +130,15 @@ func printFilterLine(label, value, defaultValue string) {
 	_, _ = fmt.Fprintf(os.Stderr, "  %s: %s\n", label, value)
 }
 
-// splitAndTrim splits a comma-separated flag value into trimmed elements,
-// returning nil for an empty string.
+// splitAndTrim splits a comma-separated flag value into trimmed, non-empty
+// elements, returning nil if none remain (e.g. for an empty string, a
+// whitespace-only value, or a trailing comma).
 func splitAndTrim(s string) []string {
-	if s == "" {
-		return nil
+	var result []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			result = append(result, p)
+		}
 	}
-	parts := strings.Split(s, ",")
-	for i, p := range parts {
-		parts[i] = strings.TrimSpace(p)
-	}
-	return parts
+	return result
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSplitAndTrim(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		want  []string
+	}{
+		"empty string returns nil": {input: "", want: nil},
+		"single value":             {input: "myorg", want: []string{"myorg"}},
+		"multiple values trimmed":  {input: "myorg, another , third", want: []string{"myorg", "another", "third"}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := splitAndTrim(tc.input); !slices.Equal(got, tc.want) {
+				t.Errorf("splitAndTrim(%q) = %#v, want %#v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -10,9 +10,12 @@ func TestSplitAndTrim(t *testing.T) {
 		input string
 		want  []string
 	}{
-		"empty string returns nil": {input: "", want: nil},
-		"single value":             {input: "myorg", want: []string{"myorg"}},
-		"multiple values trimmed":  {input: "myorg, another , third", want: []string{"myorg", "another", "third"}},
+		"empty string returns nil":    {input: "", want: nil},
+		"single value":                {input: "myorg", want: []string{"myorg"}},
+		"multiple values trimmed":     {input: "myorg, another , third", want: []string{"myorg", "another", "third"}},
+		"trailing comma drops empty":  {input: "myorg,", want: []string{"myorg"}},
+		"whitespace-only returns nil": {input: "  , ", want: nil},
+		"leading comma drops empty":   {input: ",myorg", want: []string{"myorg"}},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Summary
- `fix(github)`: merged PRs were always reported as closed with no merge date (search API only returns open/closed state); infer merged from `pull_request.merged_at`. Also guard against a nil PR/issue author, which panicked for since-deleted accounts.
- `feat(github)`: add a `-repos` flag (comma-separated `owner/repo` entries) to scope activity to specific repositories, combined with `-orgs` via AND when both are set.
- `fix(github)`: match `-orgs`/`-repos` filters case-insensitively, matching GitHub's own repo/org naming semantics.
- `refactor(github)`: extract a shared `repoFullNameFromURL` helper to dedupe URL parsing across `GetIssues`/`GetPullRequests`/`GetReviewedPullRequests`, adopt `slices.ContainsFunc`/`strings.Cut`, and move `-repos` format validation into the `github` package (the actual owner of that shape).
- `refactor(main)`: consolidate the CLI into a `run() error` with a single `os.Exit` in `main()`, extracting `splitAndTrim`/`printConfiguration`/`printFilterLine` helpers.
- `chore(makefile)`: add a race-enabled `test` target.
- `ci`: run `make test` on push to main and on every pull request.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (`go test -race ./...`)
- [x] `gofmt -l .`
- [x] `golangci-lint run ./...`
- [x] Manually ran the built binary against real GitHub data via `gh auth token`: confirmed merged PRs now show 🟣 with a merge date, `-repos` scopes results to the given repo, and `-orgs`+`-repos` combine with AND semantics (mismatched org yields 0 results, matching org yields the same count as `-repos` alone).